### PR TITLE
Add condition to avoid `IndexError`s

### DIFF
--- a/scripts/live_HORs_filter.py
+++ b/scripts/live_HORs_filter.py
@@ -35,7 +35,8 @@ for line in input_bed:
         HOR_name = line[3].split('.')[0]
         if HOR_name[-1] == 'L':
             contig_live_HORs.append(HOR_name)
-live_HORs[contig] = Counter(contig_live_HORs).most_common(1)[0][0]
+if len(contig_live_HORs) > 0:
+    live_HORs[contig] = Counter(contig_live_HORs).most_common(1)[0][0]
 
 # print chosen HORs
 for line in input_bed:


### PR DESCRIPTION
This avoids

```shell
Traceback (most recent call last):
  File "/lizardfs/guarracino/git/stv/scripts/live_HORs_filter.py", line 38, in <module>
    live_HORs[contig] = Counter(contig_live_HORs).most_common(1)[0][0]
                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```